### PR TITLE
Add Makefile.am for automake projects that want to include a library.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
-
 *.out
-
 newmain.c
-
 *.gch
+Makefile.in

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,0 +1,3 @@
+noinst_LIBRARIES = liburldecode.a
+liburldecode_a_SOURCES = urldecode.c urldecode.h
+


### PR DESCRIPTION
Thanks for this handy function. I added an automake file so it can more easily be used in larger projects with autoconf/automake.
